### PR TITLE
Automate certificate installation via the cPanel UAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@ CPANEL_AUTH_METHOD = os.environ.get("CPANEL_DNS_CPANEL_AUTH_METHOD", "password")
 # Adjust based on the performance of your DNS cluster
 CPANEL_BIND_DELAY = int(os.environ.get("CPANEL_DNS_CPANEL_DELAY", "15"))
 
-# Optional for installation: Domain to install the received certificate for
-CPANEL_TARGET_DOMAIN = os.environ.get("CPANEL_DNS_INSTALL_TARGET_DOMAIN", "example.com")
-
 # Optional for installation: Certbot configuration directory (if not the default)
 CERTBOT_CONFIG_DIR = os.environ.get("CPANEL_DNS_INSTALL_CERTBOT_CONFIG_DIR", "/etc/letsencrypt")
 ```
@@ -50,13 +47,9 @@ certbot certonly --manual \
 --preferred-challenges dns-01
 ```
 
+You can optionally add `--deploy-hook "/etc/letsencrypt/cpanel-dns.py install example.com` to install the issued certificate on the specified CPanel domain. If certificates for multiple domains are issued, you may omit specifying the domain for best-effort autodetection.
+
 If this succeeds, so should automatic renewal.
-
-5. Optionally, install the certificate:
-
-```bash
-/etc/letsencrypt/cpanel-dns.py install
-```
 
 
 ## Testing (for developers)

--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ CPANEL_AUTH_METHOD = os.environ.get("CPANEL_DNS_CPANEL_AUTH_METHOD", "password")
 
 # Adjust based on the performance of your DNS cluster
 CPANEL_BIND_DELAY = int(os.environ.get("CPANEL_DNS_CPANEL_DELAY", "15"))
-
-# Optional for installation: Certbot configuration directory (if not the default)
-CERTBOT_CONFIG_DIR = os.environ.get("CPANEL_DNS_INSTALL_CERTBOT_CONFIG_DIR", "/etc/letsencrypt")
 ```
 
 4. Try to issue a certificate now.
@@ -47,7 +44,7 @@ certbot certonly --manual \
 --preferred-challenges dns-01
 ```
 
-You can optionally add `--deploy-hook "/etc/letsencrypt/cpanel-dns.py install example.com` to install the issued certificate on the specified CPanel domain. If certificates for multiple domains are issued, you may omit specifying the domain for best-effort autodetection.
+You can optionally add `--deploy-hook "/etc/letsencrypt/cpanel-dns.py install` to install the issued certificate on the same CPanel domain as is the certificate's lineage name (in the example above: `example.com`). You can also use `... install example.com` to specify its name if your CPanel domain is different.
 
 If this succeeds, so should automatic renewal.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ It is suitable when you want to use Certbot to issue an e.g. wildcard certificat
 
 All it requires is that you have cPanel login credentials, and that your cPanel account has the ability to set TXT records.
 
+The script can optionally install the issued certificate on a selected domain via the cPanel API.
+
 ## Usage
 
 These instructions assume you are on a shell as the `root` user.
@@ -30,9 +32,15 @@ CPANEL_AUTH_METHOD = os.environ.get("CPANEL_DNS_CPANEL_AUTH_METHOD", "password")
 
 # Adjust based on the performance of your DNS cluster
 CPANEL_BIND_DELAY = int(os.environ.get("CPANEL_DNS_CPANEL_DELAY", "15"))
+
+# Optional for installation: Domain to install the received certificate for
+CPANEL_TARGET_DOMAIN = os.environ.get("CPANEL_DNS_INSTALL_TARGET_DOMAIN", "example.com")
+
+# Optional for installation: Certbot configuration directory (if not the default)
+CERTBOT_CONFIG_DIR = os.environ.get("CPANEL_DNS_INSTALL_CERTBOT_CONFIG_DIR", "/etc/letsencrypt")
 ```
 
-4. Try issue a certificate now.
+4. Try to issue a certificate now.
 
 ```bash
 certbot certonly --manual \
@@ -41,7 +49,15 @@ certbot certonly --manual \
 -d "*.my.domain.example.com" -d "*.example.com" \
 --preferred-challenges dns-01
 ```
-5. If this succeeds, so should automatic renewal.
+
+If this succeeds, so should automatic renewal.
+
+5. Optionally, install the certificate:
+
+```bash
+/etc/letsencrypt/cpanel-dns.py install
+```
+
 
 ## Testing (for developers)
 There is a basic tox integration test in place. To run it, pass the details of your cPanel server using environment variables when calling `tox`, e.g.:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ certbot certonly --manual \
 --preferred-challenges dns-01
 ```
 
-You can optionally add `--deploy-hook "/etc/letsencrypt/cpanel-dns.py install` to install the issued certificate on the same CPanel domain as is the certificate's lineage name (in the example above: `example.com`). You can also use `... install example.com` to specify its name if your CPanel domain is different.
+You can optionally add `--deploy-hook "/etc/letsencrypt/cpanel-dns.py install"` to install the issued certificate on the same cPanel domain as is the certificate's lineage name (in the example above: `example.com`). You can also use `... install example.com` to specify its name if your cPanel domain is different.
 
 If this succeeds, so should automatic renewal.
 

--- a/cpanel-dns.py
+++ b/cpanel-dns.py
@@ -173,9 +173,9 @@ if __name__ == "__main__":
             domain = sys.argv[2].strip()
         else:
             # Autodetect the domain from the certificate lineage path:
-            domain = cert_live_dir.split('/')[-1]
+            domain = os.path.basename(os.path.normpath(cert_live_dir))
 
-        print(f"Installing certificate for CPanel domain: {domain}")
+        print(f"Installing certificate for cPanel domain: {domain}")
         install_certificate(cert_live_dir, domain)
     else:
         print("Unknown action: {}".format(act))


### PR DESCRIPTION
This PR adds an extra feature that's not used by Certbot directly, but allows optional automatic installation of the generated certificate. It uses mostly the same configuration/env vars to call the cPanel `SSL/install_ssl` UAPI with the specified domain and the current live certificate.

The README is updated with the additional config vars (which are optional and used for installation only). To test this, add the new config vars, use `certbot certonly ...` to get a fresh cert and run `./cpanel-dns.py install` - the script will print the server's summary, which usually is something like `['The certificate was successfully installed on the domain “example.com”.']`.

Of course, if you'd prefer not to carry this patch, let me know and I'll close this PR - it's technically not something that Certbot can use directly, just a convenient extra.